### PR TITLE
Remove deprecated `bottle :unneeded` from two formulae

### DIFF
--- a/template-gen/template.erb
+++ b/template-gen/template.erb
@@ -3,7 +3,6 @@ class <%= $project.capitalize %> < Formula
     url "<%= @url %>"
     sha256 "<%= @sha256 %>"
     version "<%= @version %>"
-    bottle :unneeded
     
     def install
         bin.install "<%= $project %>-darwin" => "<%= $project %>"


### PR DESCRIPTION
Hi, recently, I noticed the following warning messages came to be shown:

```shell
❯ brew info arkade
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the alexellis/alexellis tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Homebrew/Library/Taps/alexellis/homebrew-alexellis/Formula/arkade.rb:6

alexellis/alexellis/arkade: stable 0.8.8
Open Source Kubernetes Marketplace
/opt/homebrew/Cellar/arkade/0.8.8 (3 files, 8MB) *
  Built from source on 2021-10-28 at 19:23:31
From: https://github.com/alexellis/homebrew-alexellis/blob/HEAD/Formula/arkade.rb
```

```
❯ brew info alexellis/homebrew-alexellis/k3sup
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the alexellis/alexellis tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Homebrew/Library/Taps/alexellis/homebrew-alexellis/Formula/k3sup.rb:6

alexellis/alexellis/k3sup: stable 0.11.0
bootstrap Kubernetes with k3s over SSH < 1 min 🚀
/opt/homebrew/Cellar/k3sup/0.11.0 (5 files, 5.2MB) *
  Poured from bottle on 2021-05-16 at 22:48:49
From: https://github.com/alexellis/homebrew-alexellis/blob/HEAD/Formula/k3sup.rb
==> Analytics
install: 73 (30 days), 258 (90 days), 1,690 (365 days)
install-on-request: 73 (30 days), 258 (90 days), 1,690 (365 days)
build-error: 0 (30 days)
```

These `bottle :unneeded` options are ignored in the latest Homebrew so they are not needed anymore. (ref. [homebrew - What does 'bottle :unneeded' do? - Stack Overflow](https://stackoverflow.com/questions/45132704/what-does-bottle-unneeded-do/45163490#45163490))

This PR removes these two lines to suppress the wanings.